### PR TITLE
Fix: neptune-endpoints-info-lambda takes longer time than expected to reflect the latest cluster status

### DIFF
--- a/gremlin-client/src/main/java/software/amazon/neptune/cluster/ClusterEndpointsRefreshAgent.java
+++ b/gremlin-client/src/main/java/software/amazon/neptune/cluster/ClusterEndpointsRefreshAgent.java
@@ -22,7 +22,9 @@ import org.slf4j.LoggerFactory;
 import software.amazon.utils.RegionUtils;
 
 import java.util.*;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -175,5 +177,9 @@ public class ClusterEndpointsRefreshAgent implements AutoCloseable {
 
     public NeptuneClusterMetadata refreshClusterMetadata() {
         return endpointsFetchStrategy.clusterMetadataSupplier().refreshClusterMetadata();
+    }
+
+    public void awake() throws InterruptedException, ExecutionException {
+        this.scheduledExecutorService.submit(() -> {}).get();
     }
 }

--- a/neptune-endpoints-info-lambda/src/main/java/software/amazon/lambda/NeptuneEndpointsInfoLambda.java
+++ b/neptune-endpoints-info-lambda/src/main/java/software/amazon/lambda/NeptuneEndpointsInfoLambda.java
@@ -58,7 +58,10 @@ public class NeptuneEndpointsInfoLambda implements RequestStreamHandler {
         System.out.println(String.format("suspendedEndpoints: %s", this.suspendedEndpoints));
 
         refreshAgent.startPollingNeptuneAPI(
-                (OnNewClusterMetadata) metadata -> neptuneClusterMetadata.set(metadata),
+                (OnNewClusterMetadata) metadata -> {
+                    neptuneClusterMetadata.set(metadata);
+                    System.out.println("Refreshed cluster metadata");
+                },
                 pollingIntervalSeconds,
                 TimeUnit.SECONDS);
     }

--- a/neptune-endpoints-info-lambda/src/main/java/software/amazon/lambda/NeptuneEndpointsInfoLambda.java
+++ b/neptune-endpoints-info-lambda/src/main/java/software/amazon/lambda/NeptuneEndpointsInfoLambda.java
@@ -26,6 +26,7 @@ import java.io.*;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Scanner;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -79,6 +80,12 @@ public class NeptuneEndpointsInfoLambda implements RequestStreamHandler {
             if (!param.isEmpty()) {
                 endpointsType = EndpointsType.valueOf(param);
             }
+        }
+
+        try {
+            refreshAgent.awake();
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException("Failed to awake refresh agent", e);
         }
 
         if (endpointsType != null) {


### PR DESCRIPTION
## Issue

We experienced a long time lag for ClusterEndpointsRefreshAgent in our app to recognize a newly added neptune instance via `lambdaProxy`.

For example, after patching `neptune-endpoints-info-lambda`:
```
--- a/neptune-endpoints-info-lambda/src/main/java/software/amazon/lambda/NeptuneEndpointsInfoLambda.java
+++ b/neptune-endpoints-info-lambda/src/main/java/software/amazon/lambda/NeptuneEndpointsInfoLambda.java
@@ -58,7 +58,10 @@ public class NeptuneEndpointsInfoLambda implements RequestStreamHandler {
         System.out.println(String.format("suspendedEndpoints: %s", this.suspendedEndpoints));
 
         refreshAgent.startPollingNeptuneAPI(
-                (OnNewClusterMetadata) metadata -> neptuneClusterMetadata.set(metadata),
+                (OnNewClusterMetadata) metadata -> {
+                    neptuneClusterMetadata.set(metadata);
+                    System.out.println("Refreshed cluster metadata");
+                },
                 pollingIntervalSeconds,
                 TimeUnit.SECONDS);
     }
```
, invoking the lambda with the default `pollingIntervalSeconds` (15 seconds) at the rate of 1 request every 15 seconds (+ about 2 seconds of CLI overhead) from one client
resulted in the following refresh events:

```
2023-06-01T15:47:12.119+09:00
2023-06-01T15:55:42.176+09:00
2023-06-01T15:57:24.126+09:00
2023-06-01T16:00:48.219+09:00
2023-06-01T16:03:04.153+09:00
2023-06-01T16:07:19.251+09:00
2023-06-01T16:12:08.141+09:00
2023-06-01T16:15:15.556+09:00
2023-06-01T16:23:11.353+09:00
2023-06-01T16:25:10.197+09:00
```


The intervals of the events seem somewhat random, but about 2-13 minutes, which is far longer than the default `pollingIntervalSeconds` of 15 seconds.


This PR tries to improve the behavior above.


## TestCases

* 1: 
    - `pollingIntervalSeconds` is 15 seconds by default
    - one request every 15 seconds (+ about 2 seconds of CLI overhead) from one client
    - expects about 17 seconds between each refresh (= 1 request per refresh)

    ```
    2023-06-01T17:22:41.488+09:00
    2023-06-01T17:22:58.805+09:00
    2023-06-01T17:23:15.485+09:00
    2023-06-01T17:23:32.463+09:00
    2023-06-01T17:23:49.503+09:00
    ```

* 2: 
    - `pollingIntervalSeconds` is 15 seconds by default
    - one request every 12 seconds (+ about 2 seconds of CLI overhead) from one client
    - expects about 28 seconds between each refresh (= 2 requests per refresh)

    ```
    2023-06-01T17:26:06.836+09:00
    2023-06-01T17:26:34.526+09:00
    2023-06-01T17:27:02.402+09:00
    2023-06-01T17:27:30.784+09:00
    2023-06-01T17:27:58.561+09:00
    ```

* 3: 
    - `pollingIntervalSeconds` is 15 seconds by default
    - one request every 1 seconds (+ about 2 seconds of CLI overhead) from one client
    - expects about seconds 15-18 between each refresh (= 5 or 6 requests per refresh)

    ```
    2023-06-01T17:40:43.766+09:00
    2023-06-01T17:41:01.703+09:00
    2023-06-01T17:41:19.882+09:00
    2023-06-01T17:41:37.662+09:00
    2023-06-01T17:41:55.655+09:00
    ```

* 4: 
    - `pollingIntervalSeconds` is 15 seconds by default
    - one request every 30 seconds (+ about 2 seconds of CLI overhead) from one client
    - expects about seconds 32 seconds between each refresh (= 1 request per refresh)

    ```
    2023-06-04T12:00:14.491+09:00
    2023-06-04T12:00:46.419+09:00
    2023-06-04T12:01:18.454+09:00
    2023-06-04T12:01:50.640+09:00
    2023-06-04T12:02:22.667+09:00
    ```

## Environment

* The version we used and on which the PR is based: v2.0.0  
  (but rebased the PR onto main HEAD following v2.0.1)
* The JDK version we used: 17  
  (compiling with JDK 1.8 resulted in an error of git-commit-id-maven-plugin:
  `io.github.git-commit-id:git-commit-id-maven-plugin:5.0.0:revision (get-the-git-infos) on project gremlin-client: Execution get-the-git-infos of goal io.github.git-commit-id:git-commit-id-maven-plugin:5.0.0:revision failed: Unable to load the mojo 'revision' in the plugin 'io.github.git-commit-id:git-commit-id-maven-plugin:5.0.0' due to an API incompatibility: org.codehaus.plexus.component.repository.exception.ComponentLookupException: pl/project13/maven/git/GitCommitIdMojo has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0`)
* Lambda configuration:
    - MemorySize: 512
    - ReservedConcurrentExecutions: 1
    - Runtime: java17
    - Architecture: arm64

----

We would appreciate it if you could review, confirm, and even retest this PR.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
