### PR TITLE
 Upgrade AWS SDK from v1 to v2

### DIFF
--- a/gremlin-client-demo/pom.xml
+++ b/gremlin-client-demo/pom.xml
@@ -7,7 +7,7 @@
     <groupId>software.amazon.neptune</groupId>
     <artifactId>gremlin-client-demo</artifactId>
     <packaging>jar</packaging>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
 
     <licenses>
         <license>

--- a/gremlin-client/pom.xml
+++ b/gremlin-client/pom.xml
@@ -6,7 +6,7 @@
     <groupId>software.amazon.neptune</groupId>
     <artifactId>gremlin-client</artifactId>
     <packaging>jar</packaging>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
 
     <modelVersion>4.0.0</modelVersion>
 
@@ -22,11 +22,10 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <javac.target>1.8</javac.target>
-        <aws.sdk.version>1.12.431</aws.sdk.version>
+        <aws.sdk.version>2.30.17</aws.sdk.version>
         <gremlin.driver.version>3.7.2</gremlin.driver.version>
-        <jackson.databind.version>2.13.4.1</jackson.databind.version>
-        <jackson.dataformat.version>2.13.2</jackson.dataformat.version>
-        <sigv4.version>2.4.0</sigv4.version>
+        <jackson.databind.version>2.18.2</jackson.databind.version>
+        <sigv4.version>3.1.0</sigv4.version>
     </properties>
     
     <scm>
@@ -66,7 +65,6 @@
     </distributionManagement>
 
     <dependencies>
-
         <dependency>
             <groupId>org.apache.tinkerpop</groupId>
             <artifactId>gremlin-driver</artifactId>
@@ -80,20 +78,20 @@
         </dependency>
 
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-core</artifactId>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-core</artifactId>
             <version>${aws.sdk.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-neptune</artifactId>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>neptune</artifactId>
             <version>${aws.sdk.version}</version>
         </dependency>
 
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-lambda</artifactId>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>lambda</artifactId>
             <version>${aws.sdk.version}</version>
         </dependency>
 
@@ -101,6 +99,12 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>
             <version>1.2.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.databind.version}</version>
         </dependency>
 
         <dependency>
@@ -212,6 +216,27 @@
             <id>release</id>
             <build>
                 <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-shade-plugin</artifactId>
+                        <version>3.6.0</version>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>shade</goal>
+                                </goals>
+                                <configuration>
+                                    <relocations>
+                                        <relocation>
+                                            <pattern>com.fasterxml.jackson</pattern>
+                                            <shadedPattern>shaded.com.fasterxml.jackson</shadedPattern>
+                                        </relocation>
+                                    </relocations>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
 
                     <!-- Sign the artifact -->
                     <plugin>

--- a/gremlin-client/src/main/java/org/apache/tinkerpop/gremlin/driver/MetricsConfig.java
+++ b/gremlin-client/src/main/java/org/apache/tinkerpop/gremlin/driver/MetricsConfig.java
@@ -12,7 +12,6 @@ permissions and limitations under the License.
 
 package org.apache.tinkerpop.gremlin.driver;
 
-import com.amazonaws.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.utils.EnvironmentVariableUtils;
@@ -44,12 +43,12 @@ class MetricsConfig {
         Boolean enableMetricsSys = null;
 
         String envVar = EnvironmentVariableUtils.getOptionalEnv(PROPERTY_NAME, null);
-        if (!StringUtils.isNullOrEmpty(envVar)) {
+        if (!(envVar == null || envVar.isEmpty())) {
             enableMetricsEnv = Boolean.parseBoolean(envVar);
         }
 
         String sysProp = System.getProperty(PROPERTY_NAME, null);
-        if (!StringUtils.isNullOrEmpty(sysProp)) {
+        if (!(sysProp == null || sysProp.isEmpty())) {
             enableMetricsSys = Boolean.parseBoolean(sysProp);
         }
 

--- a/gremlin-client/src/main/java/software/amazon/neptune/cluster/ClusterEndpointsRefreshAgent.java
+++ b/gremlin-client/src/main/java/software/amazon/neptune/cluster/ClusterEndpointsRefreshAgent.java
@@ -12,19 +12,21 @@ permissions and limitations under the License.
 
 package software.amazon.neptune.cluster;
 
-import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.neptune.auth.credentials.V1toV2CredentialsProvider;
 import org.apache.tinkerpop.gremlin.driver.EndpointCollection;
 import org.apache.tinkerpop.gremlin.driver.GremlinClient;
 import org.apache.tinkerpop.gremlin.driver.RefreshTask;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.utils.RegionUtils;
 
 import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -61,12 +63,22 @@ public class ClusterEndpointsRefreshAgent implements AutoCloseable {
 
     public static ClusterEndpointsRefreshAgent lambdaProxy(String lambdaName, String region, AWSCredentialsProvider credentialsProvider) {
         return new ClusterEndpointsRefreshAgent(
+                new GetEndpointsFromLambdaProxy(lambdaName, region, V1toV2CredentialsProvider.create(credentialsProvider)));
+    }
+
+    public static ClusterEndpointsRefreshAgent lambdaProxy(String lambdaName, String region, AwsCredentialsProvider credentialsProvider) {
+        return new ClusterEndpointsRefreshAgent(
                 new GetEndpointsFromLambdaProxy(lambdaName, region, credentialsProvider));
     }
 
-    public static ClusterEndpointsRefreshAgent lambdaProxy(String lambdaName, String region, AWSCredentialsProvider credentialsProvider, ClientConfiguration clientConfiguration) {
+    public static ClusterEndpointsRefreshAgent lambdaProxy(String lambdaName, String region, AwsCredentialsProvider credentialsProvider, ClientOverrideConfiguration clientConfiguration) {
         return new ClusterEndpointsRefreshAgent(
                 new GetEndpointsFromLambdaProxy(lambdaName, region, credentialsProvider, clientConfiguration));
+    }
+
+    public static ClusterEndpointsRefreshAgent lambdaProxy(String lambdaName, String region, AwsCredentialsProvider credentialsProvider, ClientOverrideConfiguration clientConfiguration, SdkHttpClient.Builder<?> httpClientBuilder) {
+        return new ClusterEndpointsRefreshAgent(
+                new GetEndpointsFromLambdaProxy(lambdaName, region, credentialsProvider, clientConfiguration, httpClientBuilder));
     }
 
     public static ClusterEndpointsRefreshAgent lambdaProxy(String lambdaName, String region, String iamProfile) {
@@ -74,7 +86,12 @@ public class ClusterEndpointsRefreshAgent implements AutoCloseable {
                 new GetEndpointsFromLambdaProxy(lambdaName, region, iamProfile));
     }
 
-    public static ClusterEndpointsRefreshAgent lambdaProxy(String lambdaName, String region, String iamProfile, ClientConfiguration clientConfiguration) {
+    public static ClusterEndpointsRefreshAgent lambdaProxy(String lambdaName, String region, String iamProfile, ClientOverrideConfiguration clientConfiguration, SdkHttpClient.Builder<?> httpClientBuilder) {
+        return new ClusterEndpointsRefreshAgent(
+                new GetEndpointsFromLambdaProxy(lambdaName, region, iamProfile, clientConfiguration, httpClientBuilder));
+    }
+
+    public static ClusterEndpointsRefreshAgent lambdaProxy(String lambdaName, String region, String iamProfile, ClientOverrideConfiguration clientConfiguration) {
         return new ClusterEndpointsRefreshAgent(
                 new GetEndpointsFromLambdaProxy(lambdaName, region, iamProfile, clientConfiguration));
     }
@@ -89,12 +106,22 @@ public class ClusterEndpointsRefreshAgent implements AutoCloseable {
 
     public static ClusterEndpointsRefreshAgent managementApi(String clusterId, String region, AWSCredentialsProvider credentialsProvider) {
         return new ClusterEndpointsRefreshAgent(
+                new GetEndpointsFromNeptuneManagementApi(clusterId, region, V1toV2CredentialsProvider.create(credentialsProvider)));
+    }
+
+    public static ClusterEndpointsRefreshAgent managementApi(String clusterId, String region, AwsCredentialsProvider credentialsProvider) {
+        return new ClusterEndpointsRefreshAgent(
                 new GetEndpointsFromNeptuneManagementApi(clusterId, region, credentialsProvider));
     }
 
-    public static ClusterEndpointsRefreshAgent managementApi(String clusterId, String region, AWSCredentialsProvider credentialsProvider, ClientConfiguration clientConfiguration) {
+    public static ClusterEndpointsRefreshAgent managementApi(String clusterId, String region, AwsCredentialsProvider credentialsProvider, ClientOverrideConfiguration clientConfiguration) {
         return new ClusterEndpointsRefreshAgent(
                 new GetEndpointsFromNeptuneManagementApi(clusterId, region, credentialsProvider, clientConfiguration));
+    }
+
+    public static ClusterEndpointsRefreshAgent managementApi(String clusterId, String region, AwsCredentialsProvider credentialsProvider, ClientOverrideConfiguration clientConfiguration, SdkHttpClient.Builder<?> httpClientBuilder) {
+        return new ClusterEndpointsRefreshAgent(
+                new GetEndpointsFromNeptuneManagementApi(clusterId, region, credentialsProvider, clientConfiguration, httpClientBuilder));
     }
 
     public static ClusterEndpointsRefreshAgent managementApi(String clusterId, String region, String iamProfile) {
@@ -102,7 +129,7 @@ public class ClusterEndpointsRefreshAgent implements AutoCloseable {
                 new GetEndpointsFromNeptuneManagementApi(clusterId, region, iamProfile));
     }
 
-    public static ClusterEndpointsRefreshAgent managementApi(String clusterId, String region, String iamProfile, ClientConfiguration clientConfiguration ) {
+    public static ClusterEndpointsRefreshAgent managementApi(String clusterId, String region, String iamProfile, ClientOverrideConfiguration clientConfiguration ) {
         return new ClusterEndpointsRefreshAgent(
                 new GetEndpointsFromNeptuneManagementApi(clusterId, region, iamProfile, clientConfiguration));
     }

--- a/gremlin-client/src/main/java/software/amazon/neptune/cluster/HandshakeInterceptorConfigurator.java
+++ b/gremlin-client/src/main/java/software/amazon/neptune/cluster/HandshakeInterceptorConfigurator.java
@@ -17,8 +17,8 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 package software.amazon.neptune.cluster;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
 import org.apache.tinkerpop.gremlin.driver.*;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
 import java.util.stream.Collectors;
 
@@ -32,7 +32,7 @@ class HandshakeInterceptorConfigurator implements TopologyAwareBuilderConfigurat
     private final String proxyAddress;
     private final String serviceRegion;
     private final String iamProfile;
-    private final AWSCredentialsProvider credentials;
+    private final AwsCredentialsProvider credentials;
 
     private final boolean removeHostHeader;
 
@@ -44,7 +44,7 @@ class HandshakeInterceptorConfigurator implements TopologyAwareBuilderConfigurat
                                      String proxyAddress,
                                      String serviceRegion,
                                      String iamProfile,
-                                     AWSCredentialsProvider credentials,
+                                     AwsCredentialsProvider credentials,
                                      boolean removeHostHeader) {
         this.isDirectConnection = isDirectConnection;
         this.interceptor = interceptor;

--- a/gremlin-client/src/main/java/software/amazon/neptune/cluster/IamAuthConfig.java
+++ b/gremlin-client/src/main/java/software/amazon/neptune/cluster/IamAuthConfig.java
@@ -17,13 +17,13 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 package software.amazon.neptune.cluster;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.AWSCredentialsProviderChain;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
-import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
 
 import java.util.*;
 
@@ -42,7 +42,7 @@ class IamAuthConfig {
     private final boolean removeHostHeaderAfterSigning;
     private final String serviceRegion;
     private final String iamProfile;
-    private final AWSCredentialsProvider credentials;
+    private final AwsCredentialsProvider credentials;
     private final Random random = new Random(System.currentTimeMillis());
 
     IamAuthConfig(Collection<String> endpoints,
@@ -52,7 +52,7 @@ class IamAuthConfig {
                   boolean removeHostHeaderAfterSigning,
                   String serviceRegion,
                   String iamProfile,
-                  AWSCredentialsProvider credentials) {
+                  AwsCredentialsProvider credentials) {
         this.endpoints = new ArrayList<>(endpoints);
         this.port = port;
         this.enableIamAuth = enableIamAuth;
@@ -67,13 +67,13 @@ class IamAuthConfig {
         return serviceRegion;
     }
 
-    public AWSCredentialsProviderChain credentialsProviderChain() {
+    public AwsCredentialsProviderChain credentialsProviderChain() {
         if (credentials != null) {
-            return new AWSCredentialsProviderChain(Collections.singletonList(credentials));
+            return AwsCredentialsProviderChain.of(credentials);
         } else if (!iamProfile.equals(DEFAULT_PROFILE)) {
-            return new AWSCredentialsProviderChain(Collections.singletonList(new ProfileCredentialsProvider(iamProfile)));
+            return AwsCredentialsProviderChain.of(ProfileCredentialsProvider.create(iamProfile));
         } else {
-            return new DefaultAWSCredentialsProviderChain();
+            return AwsCredentialsProviderChain.of(DefaultCredentialsProvider.create());
         }
     }
 
@@ -127,7 +127,7 @@ class IamAuthConfig {
         private boolean removeHostHeaderAfterSigning = false;
         private String serviceRegion = "";
         private String iamProfile = DEFAULT_PROFILE;
-        private AWSCredentialsProvider credentials = null;
+        private AwsCredentialsProvider credentials = null;
 
         public IamAuthConfigBuilder addNeptuneEndpoints(String... endpoints) {
             this.endpoints.addAll(Arrays.asList(endpoints));
@@ -154,7 +154,7 @@ class IamAuthConfig {
             return this;
         }
 
-        public IamAuthConfigBuilder setCredentials(AWSCredentialsProvider credentials) {
+        public IamAuthConfigBuilder setCredentials(AwsCredentialsProvider credentials) {
             this.credentials = credentials;
             return this;
         }

--- a/gremlin-client/src/main/java/software/amazon/neptune/cluster/NeptuneGremlinClusterBuilder.java
+++ b/gremlin-client/src/main/java/software/amazon/neptune/cluster/NeptuneGremlinClusterBuilder.java
@@ -18,10 +18,12 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 package software.amazon.neptune.cluster;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.neptune.auth.credentials.V1toV2CredentialsProvider;
 import io.netty.handler.ssl.SslContext;
 import org.apache.tinkerpop.gremlin.driver.*;
 import org.apache.tinkerpop.gremlin.util.ser.Serializers;
 import org.apache.tinkerpop.gremlin.util.*;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
 import java.util.*;
 import java.util.function.Supplier;
@@ -45,7 +47,7 @@ public class NeptuneGremlinClusterBuilder {
     private String iamProfile = IamAuthConfig.DEFAULT_PROFILE;
     private String serviceRegion = "";
     private HandshakeInterceptor interceptor = null;
-    private AWSCredentialsProvider credentials = null;
+    private AwsCredentialsProvider credentials = null;
     private EndpointFilter endpointFilter = new SuspendedEndpoints();
 
     private NeptuneGremlinClusterBuilder() {
@@ -367,7 +369,12 @@ public class NeptuneGremlinClusterBuilder {
         return this;
     }
 
-    public NeptuneGremlinClusterBuilder credentials(final AWSCredentialsProvider credentials) {
+    public NeptuneGremlinClusterBuilder credentials(final AWSCredentialsProvider v1AwsCredentialProvider) {
+        this.credentials = V1toV2CredentialsProvider.create(v1AwsCredentialProvider);
+        return this;
+    }
+
+    public NeptuneGremlinClusterBuilder credentials(final AwsCredentialsProvider credentials) {
         this.credentials = credentials;
         return this;
     }

--- a/gremlin-client/src/main/java/software/amazon/utils/RegionUtils.java
+++ b/gremlin-client/src/main/java/software/amazon/utils/RegionUtils.java
@@ -12,17 +12,17 @@ permissions and limitations under the License.
 
 package software.amazon.utils;
 
-import com.amazonaws.regions.Region;
-import com.amazonaws.regions.Regions;
 import org.apache.commons.lang3.StringUtils;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 
 public class RegionUtils {
     public static String getCurrentRegionName(){
         String result = EnvironmentVariableUtils.getOptionalEnv("AWS_REGION", null);
         if (StringUtils.isEmpty(result)) {
-            Region currentRegion = Regions.getCurrentRegion();
+            Region currentRegion = DefaultAwsRegionProviderChain.builder().build().getRegion();
             if (currentRegion != null) {
-                result = currentRegion.getName();
+                result = currentRegion.id();
             }
         }
         return result;

--- a/neptune-endpoints-info-lambda/pom.xml
+++ b/neptune-endpoints-info-lambda/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>software.amazon.neptune</groupId>
     <artifactId>neptune-endpoints-info-lambda</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
 
     <name>neptune-endpoints-info-lambda</name>
     <description>

--- a/neptune-endpoints-info-lambda/src/main/java/software/amazon/lambda/NeptuneEndpointsInfoLambda.java
+++ b/neptune-endpoints-info-lambda/src/main/java/software/amazon/lambda/NeptuneEndpointsInfoLambda.java
@@ -18,6 +18,7 @@ import com.amazonaws.services.lambda.runtime.LambdaLogger;
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
 import org.apache.tinkerpop.gremlin.driver.Endpoint;
 import org.apache.tinkerpop.gremlin.driver.EndpointCollection;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.neptune.cluster.*;
 import software.amazon.utils.EnvironmentVariableUtils;
 import software.amazon.utils.RegionUtils;
@@ -52,7 +53,7 @@ public class NeptuneEndpointsInfoLambda implements RequestStreamHandler {
 
         this.refreshAgent = ClusterEndpointsRefreshAgent.managementApi(clusterId,
                 RegionUtils.getCurrentRegionName(),
-                new DefaultAWSCredentialsProviderChain());
+                DefaultCredentialsProvider.create());
         this.neptuneClusterMetadata.set(refreshAgent.getClusterMetadata());
         this.suspendedEndpoints = suspendedEndpoints.toLowerCase();
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>software.amazon.neptune</groupId>
     <artifactId>neptune-gremlin-client</artifactId>
     <packaging>pom</packaging>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
 
     <licenses>
         <license>


### PR DESCRIPTION
Issue  #5 

Description of changes:

Key changes:
- Migrated from AWS SDK v1 to v2:
  - Updated AWS client builders to use v2 style
  - Replaced AWS v1 credential providers with v2 equivalents
  - Updated AWS service client method calls to match v2 API
- Updated other dependencies:
  - Jackson from 2.13.x to 2.18.2
  - AWS SigV4 from 2.4.0 to 3.1.0
- Added Maven shade plugin to handle Jackson conflicts
- Added V1toV2CredentialsProvider adapter for backwards compatibility

Breaking changes:
- AWS SDK v2 has different APIs and package names
- Credentials provider interfaces have changed


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
