### PR TITLE
Added StatusEndpointFilter and a feature to ignore selected exception. Backporting to 2.0.1

### DIFF
--- a/gremlin-client-demo/src/main/java/software/amazon/neptune/ContinuousReadDemo.java
+++ b/gremlin-client-demo/src/main/java/software/amazon/neptune/ContinuousReadDemo.java
@@ -1,0 +1,265 @@
+/*
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License").
+You may not use this file except in compliance with the License.
+A copy of the License is located at
+    http://www.apache.org/licenses/LICENSE-2.0
+or in the "license" file accompanying this file. This file is distributed
+on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+express or implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
+package software.amazon.neptune;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.github.rvesse.airline.annotations.Command;
+import com.github.rvesse.airline.annotations.Option;
+import com.github.rvesse.airline.annotations.restrictions.Once;
+import com.github.rvesse.airline.annotations.restrictions.Port;
+import com.github.rvesse.airline.annotations.restrictions.PortType;
+import com.github.rvesse.airline.annotations.restrictions.RequireOnlyOne;
+import org.apache.tinkerpop.gremlin.driver.*;
+import org.apache.tinkerpop.gremlin.driver.remote.DriverRemoteConnection;
+import org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.commons.lang3.StringUtils;
+
+import software.amazon.neptune.cluster.ClusterEndpointsRefreshAgent;
+import software.amazon.neptune.cluster.EndpointsType;
+import software.amazon.neptune.cluster.NeptuneGremlinClusterBuilder;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
+
+
+import java.util.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+
+@Command(name = "continuous-read-demo", description = "Continuous read demo using the Neptune Gremlin Client")
+public class ContinuousReadDemo implements Runnable {
+
+    private static final Logger logger = LoggerFactory.getLogger(ContinuousReadDemo.class);
+
+    @Option(name = {"--cluster-id"}, description = "Amazon Neptune cluster Id")
+    @Once
+    private String clusterId;
+
+    @Option(name = {"--port"}, description = "Neptune port (optional, default 8182)")
+    @Port(acceptablePorts = {PortType.SYSTEM, PortType.USER})
+    @Once
+    private int neptunePort = 8182;
+
+    @Option(name = {"--disable-ssl"}, description = "Disables connectivity over SSL (optional, default false)")
+    @Once
+    private boolean disableSsl = false;
+
+    @Option(name = {"--enable-iam"}, description = "Enables IAM database authentication (optional, default false)")
+    @Once
+    private boolean enableIam = false;
+
+    @Option(name = {"--profile"}, description = "Credentials profile")
+    @Once
+    private String profile = "default";
+
+    @Option(name = {"--service-region"}, description = "Neptune service region (deafult us-west-2)")
+    @Once
+    private String serviceRegion = "us-west-2";
+
+    @Option(name = {"--duration"}, description = "Duration in seconds for continuous reading (default 60)")
+    @Once
+    private int durationSeconds = 60;
+
+    @Option(name = {"--min-connections"}, description = "Minimum connection pool size should be >=5 (default 5)")
+    @Once
+    private int minConnectionPoolSize = 5;
+
+    @Option(name = {"--vertex-count"}, description = "Number of test vertices to create (default 100)")
+    @Once
+    private int vertexCount = 100;
+
+    @Option(name = {"--threads"}, description = "Number of reader threads (default 20)")
+    @Once
+    private int numReaderThreads = 20;
+
+
+    @Override
+    public void run() {
+
+        if (StringUtils.isBlank(clusterId)) {
+            throw new IllegalArgumentException("You must provide --cluster-id");
+        }
+
+        minConnectionPoolSize = Math.max(5, minConnectionPoolSize); // Ensure never less than 5
+        final int maxConnectionPoolSize = minConnectionPoolSize * 5; // Always 5x of min
+
+        logger.info("Starting continuous read demo for {} seconds...", durationSeconds);
+        logger.info("Connection pool config - Min: {}, Max: {}", minConnectionPoolSize, maxConnectionPoolSize);
+
+//        ChooseEndpointStrategy strategy = new EqualConcurrentUsageEndpointStrategy();
+//        ChooseEndpointStrategy strategy = new RoundRobinEndpointStrategy();
+//        ChooseEndpointStrategy strategy = new ConcurrentUsageEndpointStrategy();
+        final EndpointFilter endpointFilter = new StatusEndpointFilter(
+                Region.of(serviceRegion),
+                ProfileCredentialsProvider.create(profile)
+        );
+
+        GremlinCluster writerCluster = null;
+        GremlinClient writerClient = null;
+        GremlinCluster readerCluster = null;
+        GremlinClient readerClient = null;
+        ClusterEndpointsRefreshAgent writerAgent = null;
+        ClusterEndpointsRefreshAgent readerAgent = null;
+        DriverRemoteConnection writerConnection = null;
+        DriverRemoteConnection readerConnection = null;
+
+        try {
+            // Setup writer refresh agent and connection with health check
+            logger.info("Setting up writer cluster with health check refresh agent...");
+            writerAgent = ClusterEndpointsRefreshAgent.managementApi(clusterId, serviceRegion, profile);
+
+            writerCluster = NeptuneGremlinClusterBuilder.build()
+                    .enableSsl(!disableSsl)
+                    .enableIamAuth(enableIam)
+                    .iamProfile(profile)
+                    .serviceRegion(serviceRegion)
+                    .addContactPoints(writerAgent.getEndpoints(EndpointsType.Primary))
+                    .port(neptunePort)
+                    .minConnectionPoolSize(minConnectionPoolSize)
+                    .maxConnectionPoolSize(maxConnectionPoolSize)
+                    .create();
+
+            writerClient = writerCluster.connect();
+
+            // Start refresh agent for writer
+            writerAgent.startPollingNeptuneAPI(
+                    writerClient,
+                    EndpointsType.Primary,
+                    30,
+                    TimeUnit.SECONDS
+            );
+
+            logger.info("Writer cluster connection established with health checks.");
+            // Create GraphTraversalSource for writer
+            writerConnection = DriverRemoteConnection.using(writerClient);
+            GraphTraversalSource gWriter = AnonymousTraversalSource.traversal().withRemote(writerConnection);
+            // Clear existing data and write vertices
+            logger.info("Preparing test data...");
+            gWriter.V().drop().iterate();
+
+            List<Object> vertexIds = new ArrayList<>();
+            for (int i = 1; i <= vertexCount; i++) {
+                Object vertexId = gWriter.addV("TestVertex")
+                        .property("name", "vertex_" + i)
+                        .property("index", i)
+                        .next()
+                        .id();
+                vertexIds.add(vertexId);
+            }
+
+            logger.info("Created {} vertices for testing.", vertexCount);
+            Thread.sleep(1000); // Wait for replication
+            try {
+                writerCluster.close();
+                writerAgent.close();
+            } catch (Exception e) {
+                // Don't do anything.
+                logger.error("Failed to close writer connection", e);
+            }
+
+            // Setup reader refresh agent and connection with health check
+            logger.info("Setting up reader cluster with health check refresh agent...");
+            readerAgent = ClusterEndpointsRefreshAgent.managementApi(clusterId, serviceRegion, profile);
+
+            readerCluster = NeptuneGremlinClusterBuilder.build()
+                    .enableSsl(!disableSsl)
+                    .enableIamAuth(enableIam)
+                    .iamProfile(profile)
+                    .serviceRegion(serviceRegion)
+                    .addContactPoints(readerAgent.getEndpoints(EndpointsType.ReadReplicas))
+                    .port(neptunePort)
+                    .minConnectionPoolSize(minConnectionPoolSize)
+                    .maxConnectionPoolSize(maxConnectionPoolSize)
+                    .maxWaitForConnection(1000)
+//                    .keepAliveInterval(10_000) // Ping every 10 seconds.
+//                    .chooseConnectionStrategySupplier(() -> strategy)
+                    .endpointFilter(endpointFilter)
+                    .create();
+
+            readerClient = readerCluster.connect();
+
+            // Start refresh agent for reader
+            readerAgent.startPollingNeptuneAPI(
+                    readerClient,
+                    EndpointsType.ReadReplicas,
+                    30,
+                    TimeUnit.SECONDS
+            );
+
+            logger.info("Reader cluster connection established with health checks.");
+
+
+            // Create GraphTraversalSource for reader
+            readerConnection = DriverRemoteConnection.using(readerClient);
+            GraphTraversalSource gReader = AnonymousTraversalSource.traversal().withRemote(readerConnection);
+
+
+            // Continuous reading for specified duration
+            logger.info("Starting continuous read operations...");
+            final long startTime = System.currentTimeMillis();
+            final long endTime = startTime + (durationSeconds * 1000L);
+            AtomicLong readCount = new AtomicLong(0);
+            Random random = new Random();
+            ExecutorService executorService = Executors.newFixedThreadPool(numReaderThreads);
+            AtomicLong lastElapsed = new AtomicLong(0);
+            final Runnable runnable = () -> {
+
+                while (System.currentTimeMillis() < endTime) {
+                    UUID uuid = UUID.randomUUID();
+                    try {
+                        // Read a random vertex
+                        logger.info("STARTING_REQUEST: {}", uuid);
+
+                        Object randomVertexId = vertexIds.get(random.nextInt(vertexIds.size()));
+                        Map<Object, Object> vertex = gReader.V(randomVertexId).valueMap(true).next();
+                        readCount.incrementAndGet();
+                        long elapsed = (System.currentTimeMillis() - startTime) / 1000;
+                        if (readCount.get() % 100 == 0 || (elapsed - lastElapsed.get()) > 1) {
+                            logger.info("Read {} vertices (elapsed: {}s)", readCount, elapsed);
+                            lastElapsed.set(elapsed);
+                        }
+
+                        logger.info("ENDING_REQUEST: {}", uuid);
+                    } catch (Exception e) {
+                        logger.error("REQUEST_ID {}, Read error",uuid, e);
+                        try {
+                            Thread.sleep(10); // Wait longer on error
+                        } catch (InterruptedException ex) {
+                            // NO OP
+                        }
+                    }
+                }
+            };
+            for (int i = 0; i < numReaderThreads; i++) {
+                executorService.execute(runnable);
+            }
+            executorService.shutdown();
+            executorService.awaitTermination(durationSeconds, TimeUnit.SECONDS);
+
+            long totalElapsed = (System.currentTimeMillis() - startTime) / 1000;
+            logger.info("Completed continuous reading: {} vertices in {} seconds", readCount, totalElapsed);
+
+        } catch (Exception e) {
+            System.err.println("Error during Neptune Countinuos Read Demo: " + e.getMessage());
+            e.printStackTrace();
+            System.exit(1);
+        } finally {
+            logger.info("Demo completed - exiting immediately");
+            System.exit(0);
+        }
+    }
+}

--- a/gremlin-client/pom.xml
+++ b/gremlin-client/pom.xml
@@ -22,11 +22,12 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <javac.target>1.8</javac.target>
-        <aws.sdk.version>1.12.431</aws.sdk.version>
+        <aws.sdk.version>2.30.17</aws.sdk.version>
+        <aws.sdk.version.v1>1.12.431</aws.sdk.version.v1>
         <gremlin.driver.version>3.6.2</gremlin.driver.version>
         <jackson.databind.version>2.13.4.1</jackson.databind.version>
         <jackson.dataformat.version>2.13.2</jackson.dataformat.version>
-        <sigv4.version>2.4.0</sigv4.version>
+        <sigv4.version>3.1.0</sigv4.version>
     </properties>
     
     <scm>
@@ -80,21 +81,27 @@
         </dependency>
 
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>neptunedata</artifactId>
+            <version>${aws.sdk.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-core</artifactId>
-            <version>${aws.sdk.version}</version>
+            <version>${aws.sdk.version.v1}</version>
         </dependency>
 
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-neptune</artifactId>
-            <version>${aws.sdk.version}</version>
+            <version>${aws.sdk.version.v1}</version>
         </dependency>
 
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-lambda</artifactId>
-            <version>${aws.sdk.version}</version>
+            <version>${aws.sdk.version.v1}</version>
         </dependency>
 
         <dependency>
@@ -118,8 +125,8 @@
 
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>2.25.0</version>
+            <artifactId>mockito-inline</artifactId>
+            <version>4.8.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/gremlin-client/src/main/java/org/apache/tinkerpop/gremlin/driver/ClientClusterCollection.java
+++ b/gremlin-client/src/main/java/org/apache/tinkerpop/gremlin/driver/ClientClusterCollection.java
@@ -54,6 +54,15 @@ class ClientClusterCollection {
         return clusters.containsKey(endpoint.getAddress());
     }
 
+    public void removeClusterWithMatchingEndpoint(EndpointCollection endpoints) {
+        removeClustersWithNoMatchingEndpoint(endpoints, cluster -> {
+            if (cluster != null) {
+                cluster.close();
+            }
+            return null;
+        }, true);
+    }
+
     public void removeClustersWithNoMatchingEndpoint(EndpointCollection endpoints) {
         removeClustersWithNoMatchingEndpoint(endpoints, cluster -> {
             if (cluster != null) {
@@ -64,9 +73,13 @@ class ClientClusterCollection {
     }
 
     void removeClustersWithNoMatchingEndpoint(EndpointCollection endpoints, Function<Cluster, Void> clusterCloseMethod) {
+        removeClustersWithNoMatchingEndpoint(endpoints, clusterCloseMethod, false);
+    }
+
+    void removeClustersWithNoMatchingEndpoint(EndpointCollection endpoints, Function<Cluster, Void> clusterCloseMethod, boolean match) {
         List<String> removalList = new ArrayList<>();
         for (String address : clusters.keySet()) {
-            if (!endpoints.containsEndpoint(new DatabaseEndpoint().withAddress(address))) {
+            if (match == endpoints.containsEndpoint(new DatabaseEndpoint().withAddress(address))) {
                 removalList.add(address);
             }
         }

--- a/gremlin-client/src/main/java/org/apache/tinkerpop/gremlin/driver/EndpointClient.java
+++ b/gremlin-client/src/main/java/org/apache/tinkerpop/gremlin/driver/EndpointClient.java
@@ -12,24 +12,54 @@ permissions and limitations under the License.
 
 package org.apache.tinkerpop.gremlin.driver;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.HashMap;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
-class EndpointClient {
+class EndpointClient implements IgnoresSelectedExceptions {
 
-    public static List<EndpointClient> create(Map<Endpoint, Cluster> endpointClusters){
-        return create(endpointClusters, cluster -> cluster.connect().init());
+    private static final Logger logger = LoggerFactory.getLogger(EndpointClient.class);
+
+    public static List<EndpointClient> create(Map<Endpoint, Cluster> endpointClusters,
+                                              Map<Class<? extends Exception>, Set<String>> explicitlySetIgnorableExceptions) {
+        return create(endpointClusters, cluster -> cluster.connect().init(), explicitlySetIgnorableExceptions);
     }
 
-    static List<EndpointClient> create(Map<Endpoint, Cluster> endpointClusters, Function<Cluster, Client> clientFactory){
+    static List<EndpointClient> create(Map<Endpoint, Cluster> endpointClusters, Function<Cluster, Client> clientFactory,
+                                       Map<Class<? extends Exception>, Set<String>> explicitlySetIgnorableExceptions) {
         List<EndpointClient> results = new ArrayList<>();
+        final Map<Class<? extends Exception>, Set<String>> ignorableExceptions = IgnoresSelectedExceptions.getIgnorableExceptions();
         for (Map.Entry<Endpoint, Cluster> entry : endpointClusters.entrySet()) {
             Cluster cluster = entry.getValue();
             Endpoint endpoint = entry.getKey();
-            Client client = clientFactory.apply(cluster);
+            final Client client;
+            try {
+                client = clientFactory.apply(cluster);
+            } catch (final Exception ex) {
+                // In case if an exception occurs then continue. Let the caller decide whether to throw an exception
+                // Or not. Based on the fact the client configuration could have multiple highly available setting
+                // with numerous endpoints. One endpoint failing shouldn't be end of the world here.
+                // If the exception caught with the signature matches either predefined ignorableExceptions or
+                // ignorableExceptions explicitly set by the builder then continue.
+                if ((ignorableExceptions.containsKey(ex.getClass()) &&
+                        ignorableExceptions.get(ex.getClass()).contains(ex.getMessage())) ||
+                    (explicitlySetIgnorableExceptions.containsKey(ex.getClass()) &&
+                            explicitlySetIgnorableExceptions.get(ex.getClass()).contains(ex.getMessage()))) {
+
+                    logger.warn("Ignoring exception for endpoint: {}", endpoint, ex);
+                    continue;
+                }
+                logger.error("Failed to create client for endpoint: {}", endpoint, ex);
+                throw ex;
+            }
+
             results.add(new EndpointClient(endpoint, client));
         }
         return results;

--- a/gremlin-client/src/main/java/org/apache/tinkerpop/gremlin/driver/GremlinClient.java
+++ b/gremlin-client/src/main/java/org/apache/tinkerpop/gremlin/driver/GremlinClient.java
@@ -41,6 +41,7 @@ public class GremlinClient extends Client implements Refreshable, AutoCloseable 
     private final ExecutorService executorService = Executors.newSingleThreadExecutor();
     private final EndpointStrategies endpointStrategies;
     private final AcquireConnectionConfig acquireConnectionConfig;
+    private final Map<Class<? extends Exception>, Set<String>> ignoreExceptionsDuringEndpointCreation;
 
     GremlinClient(Cluster cluster,
                   Settings settings,
@@ -48,7 +49,8 @@ public class GremlinClient extends Client implements Refreshable, AutoCloseable 
                   ClientClusterCollection clientClusterCollection,
                   ClusterFactory clusterFactory,
                   EndpointStrategies endpointStrategies,
-                  AcquireConnectionConfig acquireConnectionConfig) {
+                  AcquireConnectionConfig acquireConnectionConfig,
+                  Map<Class<? extends Exception>, Set<String>> ignoreExceptionsDuringEndpointCreation) {
         super(cluster, settings);
 
         this.endpointClientCollection.set(endpointClientCollection);
@@ -57,6 +59,7 @@ public class GremlinClient extends Client implements Refreshable, AutoCloseable 
         this.endpointStrategies = endpointStrategies;
         this.acquireConnectionConfig = acquireConnectionConfig;
         this.connectionAttemptManager = acquireConnectionConfig.createConnectionAttemptManager(this);
+        this.ignoreExceptionsDuringEndpointCreation = ignoreExceptionsDuringEndpointCreation;
 
         logger.info("availableEndpointFilter: {}", endpointStrategies.endpointFilter());
     }
@@ -86,7 +89,7 @@ public class GremlinClient extends Client implements Refreshable, AutoCloseable 
 
         EndpointCollection newEndpoints = acceptedEndpoints.getEndpointsWithNoCluster(clientClusterCollection);
         Map<Endpoint, Cluster> newEndpointClusters = clientClusterCollection.createClustersForEndpoints(newEndpoints);
-        List<EndpointClient> newEndpointClients = EndpointClient.create(newEndpointClusters);
+        List<EndpointClient> newEndpointClients = EndpointClient.create(newEndpointClusters, this.ignoreExceptionsDuringEndpointCreation);
 
         EndpointClientCollection newEndpointClientCollection = new EndpointClientCollection(
                 CollectionUtils.join(survivingEndpointClients, newEndpointClients),

--- a/gremlin-client/src/main/java/org/apache/tinkerpop/gremlin/driver/GremlinClusterBuilder.java
+++ b/gremlin-client/src/main/java/org/apache/tinkerpop/gremlin/driver/GremlinClusterBuilder.java
@@ -22,6 +22,9 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.HashMap;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -73,6 +76,7 @@ public class GremlinClusterBuilder {
     private OnEagerRefresh onEagerRefresh = null;
     private EndpointFilter endpointFilter;
     private HandshakeInterceptor interceptor = HandshakeInterceptor.NO_OP;
+    private Map<Class<? extends Exception>, Set<String>> ignoreExceptionsDuringEndpointCreation = new HashMap<>();
 
     private TopologyAwareBuilderConfigurator configurator = new TopologyAwareBuilderConfigurator() {
         @Override
@@ -509,6 +513,14 @@ public class GremlinClusterBuilder {
     }
 
     /**
+     * Sets the exceptions to be ignored during Endpoint Creation
+     */
+    public GremlinClusterBuilder ignoreExceptionsDuringEndpointCreation(final Map<Class<? extends Exception>, Set<String>> ignoreExceptionsDuringEndpointCreation) {
+        this.ignoreExceptionsDuringEndpointCreation = ignoreExceptionsDuringEndpointCreation;
+        return this;
+    }
+
+    /**
      * Adds the address of a Gremlin Server to the list of servers a {@link Client} will try to contact to send
      * requests to.  The address should be parseable by {@link InetAddress#getByName(String)}.  That's the only
      * validation performed at this point.  No connection to the host is attempted.
@@ -651,6 +663,6 @@ public class GremlinClusterBuilder {
             configurator.apply(builder, endpoints);
 
             return builder.create();
-        }, endpointStrategies, acquireConnectionConfig);
+        }, endpointStrategies, acquireConnectionConfig, ignoreExceptionsDuringEndpointCreation);
     }
 }

--- a/gremlin-client/src/main/java/org/apache/tinkerpop/gremlin/driver/IgnoresSelectedExceptions.java
+++ b/gremlin-client/src/main/java/org/apache/tinkerpop/gremlin/driver/IgnoresSelectedExceptions.java
@@ -1,0 +1,21 @@
+package org.apache.tinkerpop.gremlin.driver;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.Map;
+import java.util.concurrent.TimeoutException;
+
+public interface IgnoresSelectedExceptions {
+
+    public static Map<Class<? extends Exception>, Set<String>> getIgnorableExceptions() {
+        Map<Class<? extends Exception>, Set<String>> ignorableExceptions = new HashMap<>();
+
+        Set<String> ioExceptionSignatures = new HashSet<>();
+        ioExceptionSignatures.add("Operation timed out");
+        ignorableExceptions.put(IOException.class, ioExceptionSignatures);
+
+        return ignorableExceptions;
+    }
+}

--- a/gremlin-client/src/main/java/org/apache/tinkerpop/gremlin/driver/StatusEndpointFilter.java
+++ b/gremlin-client/src/main/java/org/apache/tinkerpop/gremlin/driver/StatusEndpointFilter.java
@@ -1,0 +1,112 @@
+/*
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License").
+You may not use this file except in compliance with the License.
+A copy of the License is located at
+    http://www.apache.org/licenses/LICENSE-2.0
+or in the "license" file accompanying this file. This file is distributed
+on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+express or implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
+package org.apache.tinkerpop.gremlin.driver;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.neptune.auth.credentials.V1toV2CredentialsProvider;
+import org.apache.tinkerpop.gremlin.driver.ApprovalResult;
+import org.apache.tinkerpop.gremlin.driver.Endpoint;
+import org.apache.tinkerpop.gremlin.driver.EndpointFilter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.neptunedata.NeptunedataClient;
+import software.amazon.awssdk.services.neptunedata.model.ClientTimeoutException;
+import software.amazon.awssdk.services.neptunedata.model.GetEngineStatusRequest;
+import software.amazon.awssdk.services.neptunedata.model.GetEngineStatusResponse;
+import software.amazon.neptune.cluster.SuspendedEndpoints;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.Map;
+
+public class StatusEndpointFilter implements EndpointFilter {
+
+    private static final Logger logger = LoggerFactory.getLogger(StatusEndpointFilter.class);
+
+    private static final long DEFAULT_TIMEOUT_MILLIS = 2000;
+    private static final String STATE_HEALTHY = "healthy";
+
+
+    private final Region region;
+    private final AwsCredentialsProvider credentialsProvider;
+    private final long timeoutMillis;
+
+    public StatusEndpointFilter(Region region, AwsCredentialsProvider credentialsProvider, long timeoutMillis) {
+        this.region = region;
+        this.credentialsProvider = credentialsProvider;
+        this.timeoutMillis = timeoutMillis;
+    }
+
+    public StatusEndpointFilter(Region region, AwsCredentialsProvider credentialsProvider) {
+        this(region, credentialsProvider, DEFAULT_TIMEOUT_MILLIS);
+    }
+
+    public StatusEndpointFilter(Region region, AWSCredentialsProvider credentialsProvider, long timeoutMillis) {
+        this(region, V1toV2CredentialsProvider.create(credentialsProvider), timeoutMillis);
+    }
+
+    public StatusEndpointFilter(Region region, AWSCredentialsProvider credentialsProvider) {
+        this(region, credentialsProvider, DEFAULT_TIMEOUT_MILLIS);
+    }
+
+    @Override
+    public ApprovalResult approveEndpoint(Endpoint endpoint) {
+        final Map<String, String> annotations =endpoint.getAnnotations();
+        ApprovalResult approvalResult = ApprovalResult.APPROVED;
+        if (annotations.containsKey(SuspendedEndpoints.STATE_ANNOTATION) && !(annotations.get(SuspendedEndpoints.STATE_ANNOTATION).equals(STATE_HEALTHY))) {
+            approvalResult = new ApprovalResult(false, annotations.get(SuspendedEndpoints.STATE_ANNOTATION));
+        }
+        logger.info("Approval result: {}", approvalResult);
+        return approvalResult;
+    }
+
+    @Override
+    public Endpoint enrichEndpoint(Endpoint endpoint) {
+
+        final String statusUrl = String.format("https://%s:8182/status", endpoint.getAddress());
+        final URI endpointUri = URI.create(statusUrl);
+
+        logger.info("Endpoint URI: {}", endpointUri);
+
+        final ClientOverrideConfiguration configuration = ClientOverrideConfiguration.builder()
+                .apiCallTimeout(Duration.ofMillis(timeoutMillis))
+                .build();
+
+        final NeptunedataClient client = NeptunedataClient.builder()
+                .credentialsProvider(credentialsProvider)
+                .region(region)
+                .endpointOverride(endpointUri)
+                .overrideConfiguration(configuration)
+                .build();
+
+        try {
+
+            final GetEngineStatusResponse engineStatus = client.getEngineStatus(GetEngineStatusRequest.builder().build());
+            endpoint.setAnnotation(SuspendedEndpoints.STATE_ANNOTATION, engineStatus.status());
+            logger.info("Endpoint status: {} [{}]", endpointUri, engineStatus.status());
+
+        } catch (ClientTimeoutException e) {
+            endpoint.setAnnotation(SuspendedEndpoints.STATE_ANNOTATION, e.getMessage());
+            logger.warn("Timeout while checking endpoint status: {}", endpointUri);
+        } catch (Exception e) {
+            endpoint.setAnnotation(SuspendedEndpoints.STATE_ANNOTATION, e.getMessage());
+            logger.warn("Error while checking endpoint status: {} [{}:{}]", endpointUri, e.getClass().getSimpleName(), e.getMessage());
+        } finally {
+            client.close();
+        }
+        return endpoint;
+    }
+}

--- a/gremlin-client/src/main/java/software/amazon/neptune/cluster/NeptuneGremlinClusterBuilder.java
+++ b/gremlin-client/src/main/java/software/amazon/neptune/cluster/NeptuneGremlinClusterBuilder.java
@@ -275,6 +275,14 @@ public class NeptuneGremlinClusterBuilder {
         return this;
     }
 
+    /**
+     * A HashMap containing Exceptions with corresponding signatures to ignore during endpoint creation
+     */
+    public NeptuneGremlinClusterBuilder ignoreExceptionsDuringEndpointCreation(final  Map<Class<? extends Exception>, Set<String>> ignoreExceptionsDuringEndpointCreation) {
+        innerBuilder.ignoreExceptionsDuringEndpointCreation(ignoreExceptionsDuringEndpointCreation);
+        return this;
+    }
+
     public NeptuneGremlinClusterBuilder addContactPoint(final String address) {
         this.endpoints.add(new DatabaseEndpoint().withAddress(address));
         return this;

--- a/gremlin-client/src/test/java/org/apache/tinkerpop/gremlin/driver/EndpointClientTest.java
+++ b/gremlin-client/src/test/java/org/apache/tinkerpop/gremlin/driver/EndpointClientTest.java
@@ -25,7 +25,7 @@ public class EndpointClientTest {
         endpointClusters.put(endpoint2, cluster);
         endpointClusters.put(endpoint3, cluster);
 
-        List<EndpointClient> endpointClients = EndpointClient.create(endpointClusters, c -> client);
+        List<EndpointClient> endpointClients = EndpointClient.create(endpointClusters, c -> client, new HashMap<>());
 
         assertEquals(3, endpointClients.size());
 

--- a/gremlin-client/src/test/java/org/apache/tinkerpop/gremlin/driver/StatusEndpointFilterTest.java
+++ b/gremlin-client/src/test/java/org/apache/tinkerpop/gremlin/driver/StatusEndpointFilterTest.java
@@ -1,0 +1,33 @@
+package org.apache.tinkerpop.gremlin.driver;
+
+import org.junit.Test;
+import org.junit.Assert;
+import org.mockito.Mockito;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.neptune.cluster.SuspendedEndpoints;
+
+public class StatusEndpointFilterTest {
+
+    @Test
+    public void testStatusEndpointWithHealthyStatus() throws Exception {
+        testSetup("healthy", true);
+    }
+
+    @Test
+    public void testStatusEndpointWithUnhealthyStatus() throws Exception {
+        testSetup("unhealthy", false);
+    }
+
+    private void testSetup(final String status, final boolean expectedResult) throws Exception {
+        final AwsCredentialsProvider mockCredentials = Mockito.mock(AwsCredentialsProvider.class);
+        final StatusEndpointFilter filter = new StatusEndpointFilter(Region.US_EAST_1, mockCredentials);
+        final Endpoint endpoint = new DatabaseEndpoint().withAddress("test-endpoint.com");
+
+        endpoint.setAnnotation(SuspendedEndpoints.STATE_ANNOTATION, status);
+
+        final ApprovalResult result = filter.approveEndpoint(endpoint);
+
+        Assert.assertEquals(expectedResult, result.isApproved());
+    }
+}


### PR DESCRIPTION
…s during endpoint creation  (#15)

* Enhanced Client Initialization Resilience

Improved Behavior:

- Client attempts to connect to all configured endpoints
- Creates minimum connection pool for each endpoint
- Proceeds if at least one endpoint is available
- refresh agent keeps trying to add other endpoints if they weren't available at the start because of unavailability.

* Added exception logging and fixed the exception thrown in case of endpoint unavailability.

* Added a StatusEndpointFilter, ContinuousReadDemo and feature to ignore exceptions while creating endpoints

* Updated StatusEndpointFilter.java to use Data API

---------

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
