### PR TITLE
Fix ClusterEndpointsRefreshAgent to support stop and restart

### DIFF
--- a/gremlin-client/src/main/java/software/amazon/neptune/cluster/ClusterEndpointsRefreshAgent.java
+++ b/gremlin-client/src/main/java/software/amazon/neptune/cluster/ClusterEndpointsRefreshAgent.java
@@ -171,7 +171,7 @@ public class ClusterEndpointsRefreshAgent implements AutoCloseable {
 
     private volatile ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
 
-    private AtomicBoolean isRunning = new AtomicBoolean(false);
+    private final AtomicBoolean isRunning = new AtomicBoolean(false);
 
     public ClusterEndpointsRefreshAgent(ClusterEndpointsFetchStrategy endpointsFetchStrategy) {
         this.endpointsFetchStrategy = endpointsFetchStrategy;
@@ -196,24 +196,12 @@ public class ClusterEndpointsRefreshAgent implements AutoCloseable {
                                                                      long delay,
                                                                      TimeUnit timeUnit) {
 
-        boolean isAlreadyRunning = !isRunning.compareAndSet(false, true);
-
-        if (isAlreadyRunning) {
-            throw new IllegalStateException("Refresh agent is already running");
-        }
-
         schedule(new PollingCommand(tasks, this::refreshEndpoints), delay, timeUnit);
     }
 
     public void startPollingNeptuneAPI(OnNewClusterMetadata onNewClusterMetadata,
                                        long delay,
                                        TimeUnit timeUnit) {
-
-        boolean isAlreadyRunning = !isRunning.compareAndSet(false, true);
-
-        if (isAlreadyRunning) {
-            throw new IllegalStateException("Refresh agent is already running");
-        }
 
         schedule(() -> {
             try {
@@ -229,7 +217,8 @@ public class ClusterEndpointsRefreshAgent implements AutoCloseable {
 
     /**
      * Stops polling, waiting up to 5 seconds for the in-flight polling task to terminate.
-     * Use {@link #stop(long, TimeUnit)} to supply a different timeout.
+     * Use {@link #stop(long, TimeUnit)} to supply a different timeout or to observe whether the
+     * task actually terminated.
      */
     public void stop() {
         stop(DEFAULT_TERMINATION_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
@@ -239,35 +228,43 @@ public class ClusterEndpointsRefreshAgent implements AutoCloseable {
      * Stops polling and waits for the in-flight polling task to terminate.
      * <p>
      * Waiting for termination ensures a subsequent call to {@code startPollingNeptuneAPI} cannot run a
-     * new polling task alongside the old one. Pass a timeout of zero to return without waiting, at the
-     * risk of the old and new tasks overlapping.
+     * new polling task alongside the old one. If the wait does not complete, the agent remains marked
+     * as running and a restart throws {@link IllegalStateException} rather than adding a second poller;
+     * call {@code stop} again to carry on waiting for the same task.
+     * <p>
+     * Pass a timeout of zero to return without waiting. The agent is then immediately restartable, at
+     * the risk of the old and new polling tasks overlapping.
      *
      * @param timeout  the maximum time to wait for the polling task to terminate
      * @param timeUnit the unit of the {@code timeout} argument
+     * @return {@code true} if the polling task terminated, {@code false} if the wait timed out or was
+     * interrupted, or if {@code timeout} was zero and no wait was attempted
      */
-    public void stop(long timeout, TimeUnit timeUnit) {
-
-        ScheduledExecutorService executorService;
+    public boolean stop(long timeout, TimeUnit timeUnit) {
 
         synchronized (executorServiceLock) {
-            executorService = scheduledExecutorService;
+
+            ScheduledExecutorService executorService = scheduledExecutorService;
             executorService.shutdownNow();
-        }
 
-        if (timeout <= 0) {
-            isRunning.set(false);
-            return;
-        }
-
-        try {
-            if (!executorService.awaitTermination(timeout, timeUnit)) {
-                logger.warn("Timed out waiting for the polling task to terminate");
+            if (timeout <= 0) {
+                isRunning.set(false);
+                return false;
             }
-        } catch (InterruptedException e) {
-            logger.warn("Interrupted while waiting for the polling task to terminate");
-            Thread.currentThread().interrupt();
-        } finally {
-            isRunning.set(false);
+
+            try {
+                if (executorService.awaitTermination(timeout, timeUnit)) {
+                    isRunning.set(false);
+                    return true;
+                }
+                logger.warn("Timed out waiting for the polling task to terminate. " +
+                        "The refresh agent cannot be restarted until it has terminated.");
+            } catch (InterruptedException e) {
+                logger.warn("Interrupted while waiting for the polling task to terminate");
+                Thread.currentThread().interrupt();
+            }
+
+            return false;
         }
     }
 
@@ -284,32 +281,55 @@ public class ClusterEndpointsRefreshAgent implements AutoCloseable {
         return endpointsFetchStrategy.clusterMetadataSupplier().getClusterMetadata();
     }
 
+    /**
+     * Runs a no-op on the polling thread and waits for it to complete, forcing any refresh that is
+     * already queued or in flight to finish. Use this to ensure refreshes occur in a timely manner in an
+     * environment whose execution can be suspended between invocations, such as an AWS Lambda function.
+     *
+     * @throws IllegalStateException if the agent has been stopped. Waking a stopped agent cannot resume
+     *                               polling, so recreating its executor here would start a thread that
+     *                               never polls and that outlives {@link #stop()} and {@link #close()}.
+     */
     public void awake() throws InterruptedException, ExecutionException {
         Future<?> future;
 
         synchronized (executorServiceLock) {
-            future = activeExecutorService().submit(() -> {
+            if (scheduledExecutorService.isShutdown()) {
+                throw new IllegalStateException(
+                        "Refresh agent has been stopped. Call startPollingNeptuneAPI to resume polling.");
+            }
+            future = scheduledExecutorService.submit(() -> {
             });
         }
 
         future.get();
     }
 
+    /**
+     * Marks the agent as running and schedules the polling command, recreating the executor service if it
+     * was shut down by a previous call to {@link #stop()}.
+     * <p>
+     * The whole transition happens under {@link #executorServiceLock} so that a concurrent start or stop
+     * cannot interleave: {@code isRunning} is only set once the command is scheduled, and so always
+     * reflects whether a polling task is live.
+     *
+     * @throws IllegalStateException if the agent is already running
+     */
     private void schedule(Runnable command, long delay, TimeUnit timeUnit) {
         synchronized (executorServiceLock) {
-            activeExecutorService().scheduleWithFixedDelay(command, delay, delay, timeUnit);
-        }
-    }
 
-    /**
-     * Returns the current executor service, recreating it if it has been shut down by a previous call to
-     * {@link #stop()}. Callers must hold {@link #executorServiceLock}.
-     */
-    private ScheduledExecutorService activeExecutorService() {
-        if (scheduledExecutorService.isShutdown()) {
-            scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+            if (isRunning.get()) {
+                throw new IllegalStateException("Refresh agent is already running");
+            }
+
+            if (scheduledExecutorService.isShutdown()) {
+                scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+            }
+
+            scheduledExecutorService.scheduleWithFixedDelay(command, delay, delay, timeUnit);
+
+            isRunning.set(true);
         }
-        return scheduledExecutorService;
     }
 
     private Map<? extends EndpointsSelector, EndpointCollection> refreshEndpoints(Map<EndpointsSelector, Collection<GremlinClient>> clientSelectors) {

--- a/gremlin-client/src/main/java/software/amazon/neptune/cluster/ClusterEndpointsRefreshAgent.java
+++ b/gremlin-client/src/main/java/software/amazon/neptune/cluster/ClusterEndpointsRefreshAgent.java
@@ -25,6 +25,7 @@ import software.amazon.utils.RegionUtils;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -163,8 +164,12 @@ public class ClusterEndpointsRefreshAgent implements AutoCloseable {
 
     private static final Logger logger = LoggerFactory.getLogger(ClusterEndpointsRefreshAgent.class);
 
+    private static final long TERMINATION_TIMEOUT_MILLIS = 5000;
+
     private final ClusterEndpointsFetchStrategy endpointsFetchStrategy;
-    private ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+    private final Object executorServiceLock = new Object();
+
+    private volatile ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
 
     private AtomicBoolean isRunning = new AtomicBoolean(false);
 
@@ -197,24 +202,20 @@ public class ClusterEndpointsRefreshAgent implements AutoCloseable {
             throw new IllegalStateException("Refresh agent is already running");
         }
 
-        if (scheduledExecutorService.isShutdown()) {
-            scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
-        }
-
-        PollingCommand pollingCommand = new PollingCommand(tasks, this::refreshEndpoints);
-
-        scheduledExecutorService.scheduleWithFixedDelay(pollingCommand, delay, delay, timeUnit);
+        schedule(new PollingCommand(tasks, this::refreshEndpoints), delay, timeUnit);
     }
 
     public void startPollingNeptuneAPI(OnNewClusterMetadata onNewClusterMetadata,
                                        long delay,
                                        TimeUnit timeUnit) {
 
-        if (scheduledExecutorService.isShutdown()) {
-            scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+        boolean isAlreadyRunning = !isRunning.compareAndSet(false, true);
+
+        if (isAlreadyRunning) {
+            throw new IllegalStateException("Refresh agent is already running");
         }
 
-        scheduledExecutorService.scheduleWithFixedDelay(() -> {
+        schedule(() -> {
             try {
                 NeptuneClusterMetadata clusterMetadata = refreshClusterMetadata();
                 logger.info("New cluster metadata: {}", clusterMetadata);
@@ -223,12 +224,28 @@ public class ClusterEndpointsRefreshAgent implements AutoCloseable {
                 logger.error("Error while refreshing cluster metadata", e);
             }
 
-        }, delay, delay, timeUnit);
+        }, delay, timeUnit);
     }
 
     public void stop() {
-        scheduledExecutorService.shutdownNow();
-        isRunning.set(false);
+
+        ScheduledExecutorService executorService;
+
+        synchronized (executorServiceLock) {
+            executorService = scheduledExecutorService;
+            executorService.shutdownNow();
+        }
+
+        try {
+            if (!executorService.awaitTermination(TERMINATION_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)) {
+                logger.warn("Timed out waiting for the polling task to terminate");
+            }
+        } catch (InterruptedException e) {
+            logger.warn("Interrupted while waiting for the polling task to terminate");
+            Thread.currentThread().interrupt();
+        } finally {
+            isRunning.set(false);
+        }
     }
 
     @Override
@@ -245,8 +262,31 @@ public class ClusterEndpointsRefreshAgent implements AutoCloseable {
     }
 
     public void awake() throws InterruptedException, ExecutionException {
-        this.scheduledExecutorService.submit(() -> {
-        }).get();
+        Future<?> future;
+
+        synchronized (executorServiceLock) {
+            future = activeExecutorService().submit(() -> {
+            });
+        }
+
+        future.get();
+    }
+
+    private void schedule(Runnable command, long delay, TimeUnit timeUnit) {
+        synchronized (executorServiceLock) {
+            activeExecutorService().scheduleWithFixedDelay(command, delay, delay, timeUnit);
+        }
+    }
+
+    /**
+     * Returns the current executor service, recreating it if it has been shut down by a previous call to
+     * {@link #stop()}. Callers must hold {@link #executorServiceLock}.
+     */
+    private ScheduledExecutorService activeExecutorService() {
+        if (scheduledExecutorService.isShutdown()) {
+            scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+        }
+        return scheduledExecutorService;
     }
 
     private Map<? extends EndpointsSelector, EndpointCollection> refreshEndpoints(Map<EndpointsSelector, Collection<GremlinClient>> clientSelectors) {

--- a/gremlin-client/src/main/java/software/amazon/neptune/cluster/ClusterEndpointsRefreshAgent.java
+++ b/gremlin-client/src/main/java/software/amazon/neptune/cluster/ClusterEndpointsRefreshAgent.java
@@ -164,7 +164,7 @@ public class ClusterEndpointsRefreshAgent implements AutoCloseable {
 
     private static final Logger logger = LoggerFactory.getLogger(ClusterEndpointsRefreshAgent.class);
 
-    private static final long TERMINATION_TIMEOUT_MILLIS = 5000;
+    private static final long DEFAULT_TERMINATION_TIMEOUT_MILLIS = 5000;
 
     private final ClusterEndpointsFetchStrategy endpointsFetchStrategy;
     private final Object executorServiceLock = new Object();
@@ -227,7 +227,25 @@ public class ClusterEndpointsRefreshAgent implements AutoCloseable {
         }, delay, timeUnit);
     }
 
+    /**
+     * Stops polling, waiting up to 5 seconds for the in-flight polling task to terminate.
+     * Use {@link #stop(long, TimeUnit)} to supply a different timeout.
+     */
     public void stop() {
+        stop(DEFAULT_TERMINATION_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Stops polling and waits for the in-flight polling task to terminate.
+     * <p>
+     * Waiting for termination ensures a subsequent call to {@code startPollingNeptuneAPI} cannot run a
+     * new polling task alongside the old one. Pass a timeout of zero to return without waiting, at the
+     * risk of the old and new tasks overlapping.
+     *
+     * @param timeout  the maximum time to wait for the polling task to terminate
+     * @param timeUnit the unit of the {@code timeout} argument
+     */
+    public void stop(long timeout, TimeUnit timeUnit) {
 
         ScheduledExecutorService executorService;
 
@@ -236,8 +254,13 @@ public class ClusterEndpointsRefreshAgent implements AutoCloseable {
             executorService.shutdownNow();
         }
 
+        if (timeout <= 0) {
+            isRunning.set(false);
+            return;
+        }
+
         try {
-            if (!executorService.awaitTermination(TERMINATION_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)) {
+            if (!executorService.awaitTermination(timeout, timeUnit)) {
                 logger.warn("Timed out waiting for the polling task to terminate");
             }
         } catch (InterruptedException e) {

--- a/gremlin-client/src/main/java/software/amazon/neptune/cluster/ClusterEndpointsRefreshAgent.java
+++ b/gremlin-client/src/main/java/software/amazon/neptune/cluster/ClusterEndpointsRefreshAgent.java
@@ -164,7 +164,7 @@ public class ClusterEndpointsRefreshAgent implements AutoCloseable {
     private static final Logger logger = LoggerFactory.getLogger(ClusterEndpointsRefreshAgent.class);
 
     private final ClusterEndpointsFetchStrategy endpointsFetchStrategy;
-    private final ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+    private ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
 
     private AtomicBoolean isRunning = new AtomicBoolean(false);
 
@@ -197,6 +197,10 @@ public class ClusterEndpointsRefreshAgent implements AutoCloseable {
             throw new IllegalStateException("Refresh agent is already running");
         }
 
+        if (scheduledExecutorService.isShutdown()) {
+            scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+        }
+
         PollingCommand pollingCommand = new PollingCommand(tasks, this::refreshEndpoints);
 
         scheduledExecutorService.scheduleWithFixedDelay(pollingCommand, delay, delay, timeUnit);
@@ -205,6 +209,10 @@ public class ClusterEndpointsRefreshAgent implements AutoCloseable {
     public void startPollingNeptuneAPI(OnNewClusterMetadata onNewClusterMetadata,
                                        long delay,
                                        TimeUnit timeUnit) {
+
+        if (scheduledExecutorService.isShutdown()) {
+            scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+        }
 
         scheduledExecutorService.scheduleWithFixedDelay(() -> {
             try {
@@ -220,6 +228,7 @@ public class ClusterEndpointsRefreshAgent implements AutoCloseable {
 
     public void stop() {
         scheduledExecutorService.shutdownNow();
+        isRunning.set(false);
     }
 
     @Override

--- a/gremlin-client/src/test/java/software/amazon/neptune/cluster/ClusterEndpointsRefreshAgentRestartTest.java
+++ b/gremlin-client/src/test/java/software/amazon/neptune/cluster/ClusterEndpointsRefreshAgentRestartTest.java
@@ -22,10 +22,15 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.atLeastOnce;
@@ -37,6 +42,7 @@ public class ClusterEndpointsRefreshAgentRestartTest {
 
     private static final long AWAIT_TIMEOUT_SECONDS = 10;
     private static final long POLLING_DELAY_MILLIS = 50;
+    private static final int RACE_ITERATIONS = 200;
 
     /**
      * Stops an agent that is midway through polling, then restarts it and asserts that polling resumes.
@@ -105,8 +111,12 @@ public class ClusterEndpointsRefreshAgentRestartTest {
         verify(client, atLeastOnce()).refreshEndpoints(endpoints);
     }
 
-    @Test
-    public void shouldSupportAwakeAfterStop() throws Exception {
+    /**
+     * Waking a stopped agent cannot resume polling, so it must report the problem rather than recreate an
+     * executor whose thread would never poll and would outlive the stop.
+     */
+    @Test(expected = IllegalStateException.class)
+    public void shouldThrowIfAwokenAfterStop() throws Exception {
 
         ClusterEndpointsFetchStrategy strategy = mock(ClusterEndpointsFetchStrategy.class);
         ClusterEndpointsRefreshAgent agent = new ClusterEndpointsRefreshAgent(strategy);
@@ -120,10 +130,200 @@ public class ClusterEndpointsRefreshAgentRestartTest {
         agent.startPollingNeptuneAPI(tasks, 1, TimeUnit.SECONDS);
         agent.stop();
 
+        agent.awake();
+    }
+
+    @Test
+    public void shouldSupportAwakeAfterRestart() throws Exception {
+
+        ClusterEndpointsFetchStrategy strategy = mock(ClusterEndpointsFetchStrategy.class);
+        ClusterEndpointsRefreshAgent agent = new ClusterEndpointsRefreshAgent(strategy);
+
+        GremlinClient client = mock(GremlinClient.class);
+
+        Collection<RefreshTask> tasks = Collections.singletonList(
+                new RefreshTask(client, EndpointsType.ClusterEndpoint)
+        );
+
+        agent.startPollingNeptuneAPI(tasks, 1, TimeUnit.SECONDS);
+        agent.stop();
+        agent.startPollingNeptuneAPI(tasks, 1, TimeUnit.SECONDS);
+
         try {
             agent.awake();
         } finally {
             agent.stop();
+        }
+    }
+
+    /**
+     * A stop that cannot confirm termination must leave the agent marked as running, so that a restart is
+     * rejected rather than adding a second poller alongside the one that is still going.
+     */
+    @Test
+    public void shouldRejectRestartWhenTerminationIsNotConfirmed() throws InterruptedException {
+
+        CountDownLatch polling = new CountDownLatch(1);
+        CountDownLatch releasePolling = new CountDownLatch(1);
+
+        ClusterEndpointsFetchStrategy strategy = mock(ClusterEndpointsFetchStrategy.class);
+        when(strategy.getEndpoints(anyMap(), anyBoolean())).thenAnswer(invocation -> {
+            polling.countDown();
+            boolean released = false;
+            while (!released) {
+                try {
+                    released = releasePolling.await(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    // Deliberately swallow the interrupt from shutdownNow(), standing in for a fetch that
+                    // does not respond to interruption, so the stop below cannot confirm termination.
+                }
+            }
+            return new HashMap<EndpointsSelector, EndpointCollection>();
+        });
+
+        ClusterEndpointsRefreshAgent agent = new ClusterEndpointsRefreshAgent(strategy);
+
+        GremlinClient client = mock(GremlinClient.class);
+
+        Collection<RefreshTask> tasks = Collections.singletonList(
+                new RefreshTask(client, EndpointsType.ClusterEndpoint)
+        );
+
+        try {
+            agent.startPollingNeptuneAPI(tasks, POLLING_DELAY_MILLIS, TimeUnit.MILLISECONDS);
+
+            assertTrue("Agent should be polling before being stopped",
+                    polling.await(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS));
+
+            assertFalse("stop should report that the polling task did not terminate",
+                    agent.stop(POLLING_DELAY_MILLIS, TimeUnit.MILLISECONDS));
+
+            try {
+                agent.startPollingNeptuneAPI(tasks, POLLING_DELAY_MILLIS, TimeUnit.MILLISECONDS);
+                fail("Restarting before the polling task has terminated should throw");
+            } catch (IllegalStateException e) {
+                // Expected.
+            }
+
+            releasePolling.countDown();
+
+            assertTrue("A subsequent stop should confirm termination once the task has finished",
+                    agent.stop(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS));
+
+            // The agent is restartable again now that termination has been confirmed.
+            agent.startPollingNeptuneAPI(tasks, POLLING_DELAY_MILLIS, TimeUnit.MILLISECONDS);
+        } finally {
+            releasePolling.countDown();
+            agent.stop();
+        }
+    }
+
+    /**
+     * A start that fails to schedule must not leave the agent marked as running, otherwise it can never be
+     * started again.
+     */
+    @Test
+    public void shouldRemainStartableWhenSchedulingIsRejected() {
+
+        ClusterEndpointsFetchStrategy strategy = mock(ClusterEndpointsFetchStrategy.class);
+        ClusterEndpointsRefreshAgent agent = new ClusterEndpointsRefreshAgent(strategy);
+
+        GremlinClient client = mock(GremlinClient.class);
+
+        Collection<RefreshTask> tasks = Collections.singletonList(
+                new RefreshTask(client, EndpointsType.ClusterEndpoint)
+        );
+
+        try {
+            try {
+                // A non-positive delay is rejected by scheduleWithFixedDelay.
+                agent.startPollingNeptuneAPI(tasks, 0, TimeUnit.MILLISECONDS);
+                fail("A non-positive delay should be rejected");
+            } catch (IllegalArgumentException e) {
+                // Expected.
+            }
+
+            // No polling task was scheduled, so the agent must still be startable.
+            agent.startPollingNeptuneAPI(tasks, POLLING_DELAY_MILLIS, TimeUnit.MILLISECONDS);
+        } finally {
+            agent.stop();
+        }
+    }
+
+    /**
+     * Races a start against a stop repeatedly. Whichever wins, the agent must end up in a consistent
+     * state: if a start reported success then a poller is live and a further start must be rejected,
+     * and if the agent is not running a start must be accepted.
+     * <p>
+     * This is a best-effort stress test rather than a deterministic one; the interleaving it guards
+     * against is narrow, so passing does not prove the absence of a race.
+     */
+    @Test
+    public void shouldKeepRunningStateConsistentWhenStartRacesStop() throws Exception {
+
+        ClusterEndpointsFetchStrategy strategy = mock(ClusterEndpointsFetchStrategy.class);
+        when(strategy.getEndpoints(anyMap(), anyBoolean()))
+                .thenAnswer(invocation -> new HashMap<EndpointsSelector, EndpointCollection>());
+
+        GremlinClient client = mock(GremlinClient.class);
+
+        Collection<RefreshTask> tasks = Collections.singletonList(
+                new RefreshTask(client, EndpointsType.ClusterEndpoint)
+        );
+
+        ExecutorService racers = Executors.newFixedThreadPool(2);
+
+        try {
+            for (int i = 0; i < RACE_ITERATIONS; i++) {
+
+                ClusterEndpointsRefreshAgent agent = new ClusterEndpointsRefreshAgent(strategy);
+
+                try {
+                    agent.startPollingNeptuneAPI(tasks, POLLING_DELAY_MILLIS, TimeUnit.MILLISECONDS);
+
+                    CountDownLatch start = new CountDownLatch(1);
+
+                    Future<Boolean> started = racers.submit(() -> {
+                        start.await();
+                        try {
+                            agent.startPollingNeptuneAPI(tasks, POLLING_DELAY_MILLIS, TimeUnit.MILLISECONDS);
+                            return true;
+                        } catch (IllegalStateException e) {
+                            return false;
+                        }
+                    });
+
+                    Future<?> stopped = racers.submit(() -> {
+                        start.await();
+                        agent.stop();
+                        return null;
+                    });
+
+                    start.countDown();
+
+                    boolean startSucceeded = started.get(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+                    stopped.get(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+                    if (startSucceeded) {
+                        // A poller was scheduled, so the agent must still consider itself running. If the
+                        // flag were cleared by the racing stop, this second start would silently add a
+                        // poller alongside the live one.
+                        try {
+                            agent.startPollingNeptuneAPI(tasks, POLLING_DELAY_MILLIS, TimeUnit.MILLISECONDS);
+                            fail("Start should be rejected while a polling task is live");
+                        } catch (IllegalStateException e) {
+                            // Expected.
+                        }
+                    } else {
+                        // The start lost the race, so the stop fully took effect and a restart must work.
+                        agent.startPollingNeptuneAPI(tasks, POLLING_DELAY_MILLIS, TimeUnit.MILLISECONDS);
+                    }
+                } finally {
+                    agent.stop(0, TimeUnit.MILLISECONDS);
+                }
+            }
+        } finally {
+            racers.shutdownNow();
         }
     }
 

--- a/gremlin-client/src/test/java/software/amazon/neptune/cluster/ClusterEndpointsRefreshAgentRestartTest.java
+++ b/gremlin-client/src/test/java/software/amazon/neptune/cluster/ClusterEndpointsRefreshAgentRestartTest.java
@@ -1,0 +1,79 @@
+/*
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this
+software and associated documentation files (the "Software"), to deal in the Software
+without restriction, including without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package software.amazon.neptune.cluster;
+
+import org.apache.tinkerpop.gremlin.driver.EndpointCollection;
+import org.apache.tinkerpop.gremlin.driver.GremlinClient;
+import org.apache.tinkerpop.gremlin.driver.RefreshTask;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+
+public class ClusterEndpointsRefreshAgentRestartTest {
+
+    @Test
+    public void shouldSupportStopAndRestart() {
+
+        ClusterEndpointsFetchStrategy strategy = mock(ClusterEndpointsFetchStrategy.class);
+        ClusterEndpointsRefreshAgent agent = new ClusterEndpointsRefreshAgent(strategy);
+
+        GremlinClient client = mock(GremlinClient.class);
+
+        Collection<RefreshTask> tasks = Collections.singletonList(
+                new RefreshTask(client, EndpointsType.ClusterEndpoint)
+        );
+
+        agent.startPollingNeptuneAPI(tasks, 1, TimeUnit.SECONDS);
+        agent.stop();
+
+        try {
+            agent.startPollingNeptuneAPI(tasks, 1, TimeUnit.SECONDS);
+        } catch (IllegalStateException | java.util.concurrent.RejectedExecutionException e) {
+            fail("Should be able to restart after stop, but got: " + e.getMessage());
+        } finally {
+            agent.stop();
+        }
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void shouldThrowIfStartedWhileAlreadyRunning() {
+
+        ClusterEndpointsFetchStrategy strategy = mock(ClusterEndpointsFetchStrategy.class);
+        ClusterEndpointsRefreshAgent agent = new ClusterEndpointsRefreshAgent(strategy);
+
+        GremlinClient client = mock(GremlinClient.class);
+
+        Collection<RefreshTask> tasks = Collections.singletonList(
+                new RefreshTask(client, EndpointsType.ClusterEndpoint)
+        );
+
+        try {
+            agent.startPollingNeptuneAPI(tasks, 1, TimeUnit.SECONDS);
+            agent.startPollingNeptuneAPI(tasks, 1, TimeUnit.SECONDS);
+        } finally {
+            agent.stop();
+        }
+    }
+}

--- a/gremlin-client/src/test/java/software/amazon/neptune/cluster/ClusterEndpointsRefreshAgentRestartTest.java
+++ b/gremlin-client/src/test/java/software/amazon/neptune/cluster/ClusterEndpointsRefreshAgentRestartTest.java
@@ -38,8 +38,29 @@ public class ClusterEndpointsRefreshAgentRestartTest {
     private static final long AWAIT_TIMEOUT_SECONDS = 10;
     private static final long POLLING_DELAY_MILLIS = 50;
 
+    /**
+     * Stops an agent that is midway through polling, then restarts it and asserts that polling resumes.
+     */
+    private interface StopAction {
+        void stop(ClusterEndpointsRefreshAgent agent);
+    }
+
     @Test
     public void shouldResumePollingAfterStopAndRestart() throws InterruptedException {
+        assertResumesPollingAfterRestart(ClusterEndpointsRefreshAgent::stop);
+    }
+
+    @Test
+    public void shouldResumePollingWhenStoppedWithAnExplicitTimeout() throws InterruptedException {
+        assertResumesPollingAfterRestart(agent -> agent.stop(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void shouldResumePollingWhenStoppedWithoutWaiting() throws InterruptedException {
+        assertResumesPollingAfterRestart(agent -> agent.stop(0, TimeUnit.MILLISECONDS));
+    }
+
+    private void assertResumesPollingAfterRestart(StopAction stopAction) throws InterruptedException {
 
         EndpointCollection endpoints = new EndpointCollection();
 
@@ -69,7 +90,7 @@ public class ClusterEndpointsRefreshAgentRestartTest {
             assertTrue("Agent should poll before being stopped",
                     polled.get().await(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS));
 
-            agent.stop();
+            stopAction.stop(agent);
 
             polled.set(new CountDownLatch(1));
 

--- a/gremlin-client/src/test/java/software/amazon/neptune/cluster/ClusterEndpointsRefreshAgentRestartTest.java
+++ b/gremlin-client/src/test/java/software/amazon/neptune/cluster/ClusterEndpointsRefreshAgentRestartTest.java
@@ -1,18 +1,13 @@
 /*
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this
-software and associated documentation files (the "Software"), to deal in the Software
-without restriction, including without limitation the rights to use, copy, modify,
-merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
-INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+Licensed under the Apache License, Version 2.0 (the "License").
+You may not use this file except in compliance with the License.
+A copy of the License is located at
+    http://www.apache.org/licenses/LICENSE-2.0
+or in the "license" file accompanying this file. This file is distributed
+on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+express or implied. See the License for the specific language governing
+permissions and limitations under the License.
 */
 
 package software.amazon.neptune.cluster;
@@ -26,15 +21,71 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class ClusterEndpointsRefreshAgentRestartTest {
 
+    private static final long AWAIT_TIMEOUT_SECONDS = 10;
+    private static final long POLLING_DELAY_MILLIS = 50;
+
     @Test
-    public void shouldSupportStopAndRestart() {
+    public void shouldResumePollingAfterStopAndRestart() throws InterruptedException {
+
+        EndpointCollection endpoints = new EndpointCollection();
+
+        // Swapped for a fresh latch after the restart, so the second await can only be
+        // satisfied by a poll that happened on the recreated executor.
+        AtomicReference<CountDownLatch> polled = new AtomicReference<>(new CountDownLatch(1));
+
+        ClusterEndpointsFetchStrategy strategy = mock(ClusterEndpointsFetchStrategy.class);
+        when(strategy.getEndpoints(anyMap(), anyBoolean())).thenAnswer(invocation -> {
+            Map<EndpointsSelector, EndpointCollection> results = new HashMap<>();
+            results.put(EndpointsType.ClusterEndpoint, endpoints);
+            polled.get().countDown();
+            return results;
+        });
+
+        ClusterEndpointsRefreshAgent agent = new ClusterEndpointsRefreshAgent(strategy);
+
+        GremlinClient client = mock(GremlinClient.class);
+
+        Collection<RefreshTask> tasks = Collections.singletonList(
+                new RefreshTask(client, EndpointsType.ClusterEndpoint)
+        );
+
+        try {
+            agent.startPollingNeptuneAPI(tasks, POLLING_DELAY_MILLIS, TimeUnit.MILLISECONDS);
+
+            assertTrue("Agent should poll before being stopped",
+                    polled.get().await(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS));
+
+            agent.stop();
+
+            polled.set(new CountDownLatch(1));
+
+            agent.startPollingNeptuneAPI(tasks, POLLING_DELAY_MILLIS, TimeUnit.MILLISECONDS);
+
+            assertTrue("Agent should resume polling after being restarted",
+                    polled.get().await(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS));
+        } finally {
+            agent.stop();
+        }
+
+        verify(client, atLeastOnce()).refreshEndpoints(endpoints);
+    }
+
+    @Test
+    public void shouldSupportAwakeAfterStop() throws Exception {
 
         ClusterEndpointsFetchStrategy strategy = mock(ClusterEndpointsFetchStrategy.class);
         ClusterEndpointsRefreshAgent agent = new ClusterEndpointsRefreshAgent(strategy);
@@ -49,9 +100,7 @@ public class ClusterEndpointsRefreshAgentRestartTest {
         agent.stop();
 
         try {
-            agent.startPollingNeptuneAPI(tasks, 1, TimeUnit.SECONDS);
-        } catch (IllegalStateException | java.util.concurrent.RejectedExecutionException e) {
-            fail("Should be able to restart after stop, but got: " + e.getMessage());
+            agent.awake();
         } finally {
             agent.stop();
         }
@@ -72,6 +121,23 @@ public class ClusterEndpointsRefreshAgentRestartTest {
         try {
             agent.startPollingNeptuneAPI(tasks, 1, TimeUnit.SECONDS);
             agent.startPollingNeptuneAPI(tasks, 1, TimeUnit.SECONDS);
+        } finally {
+            agent.stop();
+        }
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void shouldThrowIfClusterMetadataPollingStartedWhileAlreadyRunning() {
+
+        ClusterEndpointsFetchStrategy strategy = mock(ClusterEndpointsFetchStrategy.class);
+        ClusterEndpointsRefreshAgent agent = new ClusterEndpointsRefreshAgent(strategy);
+
+        OnNewClusterMetadata onNewClusterMetadata = metadata -> {
+        };
+
+        try {
+            agent.startPollingNeptuneAPI(onNewClusterMetadata, 1, TimeUnit.SECONDS);
+            agent.startPollingNeptuneAPI(onNewClusterMetadata, 1, TimeUnit.SECONDS);
         } finally {
             agent.stop();
         }


### PR DESCRIPTION
## Summary
- `stop()` now resets `isRunning` to `false`, allowing `startPollingNeptuneAPI` to be called again without throwing `IllegalStateException`
- Both `startPollingNeptuneAPI` overloads lazily recreate the `ScheduledExecutorService` if it was previously shut down, preventing `RejectedExecutionException`
- `scheduledExecutorService` field is no longer `final` to allow reassignment after shutdown
- Added unit test (`ClusterEndpointsRefreshAgentRestartTest`) verifying stop-and-restart works and that double-start still throws

## Test plan
- [x] `mvn test -pl gremlin-client` passes locally
- [x] New test `ClusterEndpointsRefreshAgentRestartTest.shouldSupportStopAndRestart` verifies the fix
- [x] New test `ClusterEndpointsRefreshAgentRestartTest.shouldThrowIfStartedWhileAlreadyRunning` verifies existing behavior is preserved